### PR TITLE
Restrict players from sending colored messages without permission

### DIFF
--- a/src/main/java/me/lucko/gchat/GChatListener.java
+++ b/src/main/java/me/lucko/gchat/GChatListener.java
@@ -115,7 +115,7 @@ public class GChatListener implements Listener {
         // get the players message, and remove any color if they don't have permission for it.
         String playerMessage = e.getMessage();
         if (!player.hasPermission("gchat.color")) {
-            playerMessage = ChatColor.stripColor(playerMessage);
+            playerMessage = ChatColor.stripColor(playerMessage.replaceAll("&[0-9a-f]",""));
         }
 
         // apply the players message to the chat format


### PR DESCRIPTION
Current implementation calls ChatColor.stripColor() to remove colors from player source message, but this doesn't remove any &1, etc. color codes the player embedded. A few lines further down these tags are transformed into color codes which no permission exists to prevent. 

This fix isn't perfect - it strips potentially valid usages of the & in chat. Feel free to abandon it and implement something better. 

Signed-off-by: Byron Marohn <combustible@live.com>