### PR TITLE
Update pom.xml to prevent IDE import errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
                 </includes>
             </resource>
             <resource>
-                <directory>/</directory>
+                <directory>.</directory>
                 <filtering>false</filtering>
                 <includes>
                     <include>LICENSE.txt</include>


### PR DESCRIPTION
Prevents an issue when importing into IntelliJ IDEA where `/` gets added to the project.